### PR TITLE
Use SAP help documents for Kyma references in the observability section

### DIFF
--- a/documentation/observability/5-deploy-to-kyma.md
+++ b/documentation/observability/5-deploy-to-kyma.md
@@ -4,7 +4,7 @@
 
 To start streaming logs, metrics and traces from SAP BTP, Kyma runtime to the SAP Cloud Logging service, you need to follow these steps:
 
-1. Enable the Kyma [Telemetry module](https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-telemetry-module) by following the steps described in [Add and Delete a Kyma Module Using Kyma Dashboard](https://help.sap.com/docs/btp/sap-business-technology-platform/enable-and-disable-kyma-module).
+1. Add the Kyma [Telemetry module](https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-telemetry-module) by following the steps described in [Add and Delete a Kyma Module Using Kyma Dashboard](https://help.sap.com/docs/btp/sap-business-technology-platform/enable-and-disable-kyma-module).
 
 2. An instance of SAP Cloud Logging with OpenTelemetry is enabled to ingest distributed traces and metrics.
 

--- a/documentation/observability/5-deploy-to-kyma.md
+++ b/documentation/observability/5-deploy-to-kyma.md
@@ -4,20 +4,20 @@
 
 To start streaming logs, metrics and traces from SAP BTP, Kyma runtime to the SAP Cloud Logging service, you need to follow these steps:
 
-1. Enable the Kyma [Telemetry module](https://kyma-project.io/#/telemetry-manager/user/README) by following the steps described as [Quick Install of kyma-project.io](https://kyma-project.io/#/02-get-started/01-quick-install).
+1. Enable the Kyma [Telemetry module](https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-telemetry-module) by following the steps described in [Add and Delete a Kyma Module Using Kyma Dashboard](https://help.sap.com/docs/btp/sap-business-technology-platform/enable-and-disable-kyma-module).
 
-2. An instance of SAP Cloud Logging with OpenTelemetry is enabled to ingest distributed traces.
+2. An instance of SAP Cloud Logging with OpenTelemetry is enabled to ingest distributed traces and metrics.
 
 > [!TIP]
 >We recommend that you create an instance of SAP Cloud Logging with the SAP BTP service operator, because it takes care of creation and rotation of the required secret. See [Create an SAP Cloud Logging Instance through SAP BTP Service Operator](https://help.sap.com/docs/cloud-logging/cloud-logging/create-sap-cloud-logging-instance-through-sap-btp-service-operator)
-However, you can choose any other method of creating the instance and the secret, as long as the parameter for the OTLP ingestion is enabled in the instance. For details, see [Configuration Parameters](https://help.sap.com/docs/cloud-logging/cloud-logging/configuration-parameters?locale=en-US&version=Cloud).
+However, you can choose any other method of creating the instance and the secret, as long as the parameter for the OTLP ingestion is enabled in the instance. For details, see [Configuration Parameters](https://help.sap.com/docs/cloud-logging/cloud-logging/configuration-parameters).
 
 To create the SAP Cloud Logging service instance, follow these steps:
 
 1. Log in to the Kyma cluster.
 
 > [!TIP]
-> To log in to the Kyma cluster, follow the [Log In to Your Kyma cluster](https://developers.sap.com/tutorials/deploy-to-kyma.html#1206fdc5-e6d4-4238-8cef-638cc7739ca6) tutorial.
+> To log in to the Kyma cluster, follow the [Access a Kyma Instance Using kubectl](https://help.sap.com/docs/btp/sap-business-technology-platform/access-kyma-instance-using-kubectl) instructions.
 
 1. Create a namespace with the following command:
    
@@ -25,13 +25,13 @@ To create the SAP Cloud Logging service instance, follow these steps:
     kubectl create namespace sap-cloud-logging-integration 
     ```
 
-2. Create a new file called `cls.yaml` and paste the following code:
+2. Create a new file called `cloud-logging-instance.yaml` and paste the following code:
 
     ```
-    apiVersion: services.cloud.sap.com/v1alpha1
+    apiVersion: services.cloud.sap.com/v1
     kind: ServiceInstance
     metadata:
-      name: created-with-sap-btp-service-operators
+      name: sap-cloud-logging
     spec:
       serviceOfferingName: cloud-logging
       servicePlanName: standard
@@ -43,7 +43,7 @@ To create the SAP Cloud Logging service instance, follow these steps:
 3. Apply the configuration with the following command:
 
     ```
-    kubectl apply -n sap-cloud-logging-integration -f cls.yaml 
+    kubectl apply -n sap-cloud-logging-integration -f cloud-logging-instance.yaml 
     ```
        
 4. Wait for the instance to be created, you can check its status using the following command:
@@ -51,7 +51,7 @@ To create the SAP Cloud Logging service instance, follow these steps:
     ```
     kubectl get serviceinstances.services.cloud.sap.com -o yaml -n sap-cloud-logging-integration
     ```
-5. Once the instance is created, create a binding that will provide the required SAP Cloud Logging service secret. Create a file called: `clsbinding.yaml` and paste the following code: 
+5. Once the instance is created, create a binding that will provide the required SAP Cloud Logging service secret. Create a file called: `cloud-logging-binding.yaml` and paste the following code: 
 
     ```
     apiVersion: services.cloud.sap.com/v1
@@ -59,7 +59,7 @@ To create the SAP Cloud Logging service instance, follow these steps:
     metadata:
       name: cls-binding
     spec:
-      serviceInstanceName: created-with-sap-btp-service-operators
+      serviceInstanceName: sap-cloud-logging
       externalName: cloud-logging-created-with-sap-btp-service-operators
       secretName: sap-cloud-logging
       credentialsRotationPolicy:
@@ -69,14 +69,14 @@ To create the SAP Cloud Logging service instance, follow these steps:
     ```
     To apply the configuration, use the following command:
     ```
-    kubectl apply -n sap-cloud-logging-integration -f clsbinding.yaml
+    kubectl apply -n sap-cloud-logging-integration -f cloud-logging-binding.yaml
     ```
     
-7. Ship the logs to the SAP Cloud Logging service. See [Ship Logs to SAP Cloud Logging](https://kyma-project.io/#/telemetry-manager/user/integration/sap-cloud-logging/README?id=ship-logs-to-sap-cloud-logging).
+7. Ship the logs to the SAP Cloud Logging service. See [Ship Logs to SAP Cloud Logging](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?ship-logs-to-sap-cloud-logging).
 
-8. Ship the distributed traces to the SAP Cloud Logging service. See [Ship Distributed Traces to SAP Cloud Logging](https://kyma-project.io/#/telemetry-manager/user/integration/sap-cloud-logging/README?id=ship-distributed-traces-to-sap-cloud-logging).
+8. Ship the distributed traces to the SAP Cloud Logging service. See [Ship Distributed Traces to SAP Cloud Logging](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?ship-distributed-traces-to-sap-cloud-logging).
 
-9. Ship the metrics to the SAP Cloud Logging service. See [Ship Metrics to SAP Cloud Logging](https://kyma-project.io/#/telemetry-manager/user/integration/sap-cloud-logging/README?id=ship-metrics-to-sap-cloud-logging).
+9. Ship the metrics to the SAP Cloud Logging service. See [Ship Metrics to SAP Cloud Logging](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?ship-metrics-to-sap-cloud-logging).
 
     Once the configurations are applied, you can check the status of all telemetry configurations in the Kyma dashboard. They should look like this: 
     <img src="./images/pipelines.png" />

--- a/documentation/observability/5-deploy-to-kyma.md
+++ b/documentation/observability/5-deploy-to-kyma.md
@@ -87,9 +87,10 @@ To create an SAP Cloud Logging instance and start streaming logs, metrics, and t
 
 1.  For easier access, adjust the Kyma dashboard navigation. See [Kyma Dashboard Integration](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?locale=en-US&version=Cloud#set-up-kyma-dashboard-integration).
 
-# Deploy the Incident Management Application in the SAP BTP, Kyma Runtime
+## Deploy the Incident Management Application in the SAP BTP, Kyma Runtime
 
 Follow the steps in the [Deploy a Full-Stack CAP Application in SAP BTP, Kyma Runtime](https://developers.sap.com/group.deploy-full-stack-cap-kyma-runtime.html) tutorial.
 
-# Visualize Logs, Metrics and Traces
-- [Access custom logs, metrics, traces](./6-test-the-flow.md)
+## Visualize Logs, Metrics and Traces
+
+Verify the setup and [access custom logs, metrics, traces](./6-test-the-flow.md) of your deployed application in the newly provisioned SAP Cloud Logging instance.

--- a/documentation/observability/5-deploy-to-kyma.md
+++ b/documentation/observability/5-deploy-to-kyma.md
@@ -7,12 +7,12 @@
 
 ## Set Up SAP Cloud Logging and integrate it with the SAP BTP, Kyma runtime
 
-To create a SAP Cloud Logging instance and start streaming logs, metrics and traces from SAP BTP, Kyma runtime to the instance, you need to follow these steps:
+To create an SAP Cloud Logging instance and start streaming logs, metrics, and traces from SAP BTP, Kyma runtime to the instance, you need to follow these steps:
 
 1. Log in to the Kyma cluster.
 
    > [!TIP]
-   > To log in to the Kyma cluster, follow the [Access a Kyma Instance Using kubectl](https://help.sap.com/docs/btp/sap-business-technology-platform/access-kyma-instance-using-kubectl) instructions.
+   > To log in to the Kyma cluster, follow [Access a Kyma Instance Using kubectl](https://help.sap.com/docs/btp/sap-business-technology-platform/access-kyma-instance-using-kubectl).
 
 1. Create a namespace with the following command:
    
@@ -35,16 +35,16 @@ To create a SAP Cloud Logging instance and start streaming logs, metrics and tra
         ingest_otlp:
           enabled: true
     ```
-    The `ingest_otlp` will enable support for OpenTelemetry based data, which is required for the ingestion of distributed traces and metrics.
+    The `ingest_otlp` will enable support for OpenTelemetry-based data, which is required for the ingestion of distributed traces and metrics.
 
 1. Apply the configuration with the following command:
 
     ```
     kubectl apply -n sap-cloud-logging-integration -f cloud-logging-instance.yaml 
     ```
-    This will trigger the provisioning of a SAP CLoud Logging instance
+    This will trigger the provisioning of a SAP Cloud Logging instance
    > [!TIP]
-   > In this guide you create an instance of SAP Cloud Logging with the SAP BTP service operator, which is the recommended way. It takes care of creation and periodic rotation of the required secret. See [Create an SAP Cloud Logging Instance through SAP BTP Service Operator](https://help.sap.com/docs/cloud-logging/cloud-logging/create-sap-cloud-logging-instance-through-sap-btp-service-operator)
+   > In this guide, you create an instance of SAP Cloud Logging with the SAP BTP service operator, which is the recommended way. It takes care of creation and periodic rotation of the required secret. See [Create an SAP Cloud Logging Instance through SAP BTP Service Operator](https://help.sap.com/docs/cloud-logging/cloud-logging/create-sap-cloud-logging-instance-through-sap-btp-service-operator).
    However, you can choose any other method of creating the instance and the secret, as long as the parameter for the OTLP ingestion is enabled in the instance. For details, see [Configuration Parameters](https://help.sap.com/docs/cloud-logging/cloud-logging/configuration-parameters).
 
 1. Wait for the instance to be created. You can check its status using the following command:
@@ -85,7 +85,7 @@ To create a SAP Cloud Logging instance and start streaming logs, metrics and tra
     > [!TIP]
     > Learn how to access [Kyma dashboard](https://learning.sap.com/learning-journeys/deliver-side-by-side-extensibility-based-on-sap-btp-kyma-runtime/using-the-kyma-dashboard_d23b12a1-d17c-491d-a80b-cb78039e317e).
 
-1.  [Kyma Dashboard Integration](https://kyma-project.io/#/telemetry-manager/user/integration/sap-cloud-logging/README?id=ship-metrics-to-sap-cloud-logging).
+1.  For easier access, adjust the Kyma dashboard navigation. See [Kyma Dashboard Integration](https://kyma-project.io/#/telemetry-manager/user/integration/sap-cloud-logging/README?id=set-up-kyma-dashboard-integration).
 
 # Deploy the Incident Management Application in the SAP BTP, Kyma Runtime
 

--- a/documentation/observability/5-deploy-to-kyma.md
+++ b/documentation/observability/5-deploy-to-kyma.md
@@ -8,16 +8,16 @@ To start streaming logs, metrics and traces from SAP BTP, Kyma runtime to the SA
 
 2. An instance of SAP Cloud Logging with OpenTelemetry is enabled to ingest distributed traces and metrics.
 
-> [!TIP]
->We recommend that you create an instance of SAP Cloud Logging with the SAP BTP service operator, because it takes care of creation and rotation of the required secret. See [Create an SAP Cloud Logging Instance through SAP BTP Service Operator](https://help.sap.com/docs/cloud-logging/cloud-logging/create-sap-cloud-logging-instance-through-sap-btp-service-operator)
-However, you can choose any other method of creating the instance and the secret, as long as the parameter for the OTLP ingestion is enabled in the instance. For details, see [Configuration Parameters](https://help.sap.com/docs/cloud-logging/cloud-logging/configuration-parameters).
+   > [!TIP]
+   >We recommend that you create an instance of SAP Cloud Logging with the SAP BTP service operator, because it takes care of creation and rotation of the required secret. See [Create an SAP Cloud Logging Instance through SAP BTP Service Operator](https://help.sap.com/docs/cloud-logging/cloud-logging/create-sap-cloud-logging-instance-through-sap-btp-service-operator)
+   However, you can choose any other method of creating the instance and the secret, as long as the parameter for the OTLP ingestion is enabled in the instance. For details, see [Configuration Parameters](https://help.sap.com/docs/cloud-logging/cloud-logging/configuration-parameters).
 
 To create the SAP Cloud Logging service instance, follow these steps:
 
 1. Log in to the Kyma cluster.
 
-> [!TIP]
-> To log in to the Kyma cluster, follow the [Access a Kyma Instance Using kubectl](https://help.sap.com/docs/btp/sap-business-technology-platform/access-kyma-instance-using-kubectl) instructions.
+   > [!TIP]
+   > To log in to the Kyma cluster, follow the [Access a Kyma Instance Using kubectl](https://help.sap.com/docs/btp/sap-business-technology-platform/access-kyma-instance-using-kubectl) instructions.
 
 1. Create a namespace with the following command:
    
@@ -25,7 +25,7 @@ To create the SAP Cloud Logging service instance, follow these steps:
     kubectl create namespace sap-cloud-logging-integration 
     ```
 
-2. Create a new file called `cloud-logging-instance.yaml` and paste the following code:
+1. Create a new file called `cloud-logging-instance.yaml` and paste the following code:
 
     ```
     apiVersion: services.cloud.sap.com/v1
@@ -40,18 +40,18 @@ To create the SAP Cloud Logging service instance, follow these steps:
         ingest_otlp:
           enabled: true
     ```
-3. Apply the configuration with the following command:
+1. Apply the configuration with the following command:
 
     ```
     kubectl apply -n sap-cloud-logging-integration -f cloud-logging-instance.yaml 
     ```
        
-4. Wait for the instance to be created, you can check its status using the following command:
+1. Wait for the instance to be created, you can check its status using the following command:
 
     ```
     kubectl get serviceinstances.services.cloud.sap.com -o yaml -n sap-cloud-logging-integration
     ```
-5. Once the instance is created, create a binding that will provide the required SAP Cloud Logging service secret. Create a file called: `cloud-logging-binding.yaml` and paste the following code: 
+1. Once the instance is created, create a binding that will provide the required SAP Cloud Logging service secret. Create a file called: `cloud-logging-binding.yaml` and paste the following code: 
 
     ```
     apiVersion: services.cloud.sap.com/v1
@@ -72,11 +72,11 @@ To create the SAP Cloud Logging service instance, follow these steps:
     kubectl apply -n sap-cloud-logging-integration -f cloud-logging-binding.yaml
     ```
     
-7. Ship the logs to the SAP Cloud Logging service. See [Ship Logs to SAP Cloud Logging](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?ship-logs-to-sap-cloud-logging).
+1. Ship the logs to the SAP Cloud Logging service. See [Ship Logs to SAP Cloud Logging](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?ship-logs-to-sap-cloud-logging).
 
-8. Ship the distributed traces to the SAP Cloud Logging service. See [Ship Distributed Traces to SAP Cloud Logging](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?ship-distributed-traces-to-sap-cloud-logging).
+1. Ship the distributed traces to the SAP Cloud Logging service. See [Ship Distributed Traces to SAP Cloud Logging](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?ship-distributed-traces-to-sap-cloud-logging).
 
-9. Ship the metrics to the SAP Cloud Logging service. See [Ship Metrics to SAP Cloud Logging](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?ship-metrics-to-sap-cloud-logging).
+1. Ship the metrics to the SAP Cloud Logging service. See [Ship Metrics to SAP Cloud Logging](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?ship-metrics-to-sap-cloud-logging).
 
     Once the configurations are applied, you can check the status of all telemetry configurations in the Kyma dashboard. They should look like this: 
     <img src="./images/pipelines.png" />
@@ -84,7 +84,7 @@ To create the SAP Cloud Logging service instance, follow these steps:
     > [!TIP]
     > Learn how to access [Kyma dashboard](https://learning.sap.com/learning-journeys/deliver-side-by-side-extensibility-based-on-sap-btp-kyma-runtime/using-the-kyma-dashboard_d23b12a1-d17c-491d-a80b-cb78039e317e).
 
-10.  [Kyma Dashboard Integration](https://kyma-project.io/#/telemetry-manager/user/integration/sap-cloud-logging/README?id=ship-metrics-to-sap-cloud-logging).
+1.  [Kyma Dashboard Integration](https://kyma-project.io/#/telemetry-manager/user/integration/sap-cloud-logging/README?id=ship-metrics-to-sap-cloud-logging).
 
 # Deploy the Incident Management Application in the SAP BTP, Kyma Runtime
 

--- a/documentation/observability/5-deploy-to-kyma.md
+++ b/documentation/observability/5-deploy-to-kyma.md
@@ -46,7 +46,7 @@ To create the SAP Cloud Logging service instance, follow these steps:
     kubectl apply -n sap-cloud-logging-integration -f cloud-logging-instance.yaml 
     ```
        
-1. Wait for the instance to be created, you can check its status using the following command:
+1. Wait for the instance to be created. You can check its status using the following command:
 
     ```
     kubectl get serviceinstances.services.cloud.sap.com -o yaml -n sap-cloud-logging-integration

--- a/documentation/observability/5-deploy-to-kyma.md
+++ b/documentation/observability/5-deploy-to-kyma.md
@@ -85,7 +85,7 @@ To create an SAP Cloud Logging instance and start streaming logs, metrics, and t
     > [!TIP]
     > Learn how to access [Kyma dashboard](https://learning.sap.com/learning-journeys/deliver-side-by-side-extensibility-based-on-sap-btp-kyma-runtime/using-the-kyma-dashboard_d23b12a1-d17c-491d-a80b-cb78039e317e).
 
-1.  For easier access, adjust the Kyma dashboard navigation. See [Kyma Dashboard Integration](https://kyma-project.io/#/telemetry-manager/user/integration/sap-cloud-logging/README?id=set-up-kyma-dashboard-integration).
+1.  For easier access, adjust the Kyma dashboard navigation. See [Kyma Dashboard Integration](https://help.sap.com/docs/btp/sap-business-technology-platform/integrate-with-sap-cloud-logging?locale=en-US&version=Cloud#set-up-kyma-dashboard-integration).
 
 # Deploy the Incident Management Application in the SAP BTP, Kyma Runtime
 

--- a/documentation/observability/5-deploy-to-kyma.md
+++ b/documentation/observability/5-deploy-to-kyma.md
@@ -1,18 +1,13 @@
 # Enable Observability in the SAP BTP, Kyma Runtime
 
-## Set Up the SAP Cloud Logging Service
+## Prerequisites
 
-To start streaming logs, metrics and traces from SAP BTP, Kyma runtime to the SAP Cloud Logging service, you need to follow these steps:
+- Add the Kyma [Telemetry module](https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-telemetry-module) by following the steps described in [Add and Delete a Kyma Module Using Kyma Dashboard](https://help.sap.com/docs/btp/sap-business-technology-platform/enable-and-disable-kyma-module).
+- Have an entitlement for the service `cloud-logging` assigned to your subaccount.
 
-1. Add the Kyma [Telemetry module](https://help.sap.com/docs/btp/sap-business-technology-platform/kyma-telemetry-module) by following the steps described in [Add and Delete a Kyma Module Using Kyma Dashboard](https://help.sap.com/docs/btp/sap-business-technology-platform/enable-and-disable-kyma-module).
+## Set Up SAP Cloud Logging and integrate it with the SAP BTP, Kyma runtime
 
-2. An instance of SAP Cloud Logging with OpenTelemetry is enabled to ingest distributed traces and metrics.
-
-   > [!TIP]
-   >We recommend that you create an instance of SAP Cloud Logging with the SAP BTP service operator, because it takes care of creation and rotation of the required secret. See [Create an SAP Cloud Logging Instance through SAP BTP Service Operator](https://help.sap.com/docs/cloud-logging/cloud-logging/create-sap-cloud-logging-instance-through-sap-btp-service-operator)
-   However, you can choose any other method of creating the instance and the secret, as long as the parameter for the OTLP ingestion is enabled in the instance. For details, see [Configuration Parameters](https://help.sap.com/docs/cloud-logging/cloud-logging/configuration-parameters).
-
-To create the SAP Cloud Logging service instance, follow these steps:
+To create a SAP Cloud Logging instance and start streaming logs, metrics and traces from SAP BTP, Kyma runtime to the instance, you need to follow these steps:
 
 1. Log in to the Kyma cluster.
 
@@ -40,12 +35,18 @@ To create the SAP Cloud Logging service instance, follow these steps:
         ingest_otlp:
           enabled: true
     ```
+    The `ingest_otlp` will enable support for OpenTelemetry based data, which is required for the ingestion of distributed traces and metrics.
+
 1. Apply the configuration with the following command:
 
     ```
     kubectl apply -n sap-cloud-logging-integration -f cloud-logging-instance.yaml 
     ```
-       
+    This will trigger the provisioning of a SAP CLoud Logging instance
+   > [!TIP]
+   > In this guide you create an instance of SAP Cloud Logging with the SAP BTP service operator, which is the recommended way. It takes care of creation and periodic rotation of the required secret. See [Create an SAP Cloud Logging Instance through SAP BTP Service Operator](https://help.sap.com/docs/cloud-logging/cloud-logging/create-sap-cloud-logging-instance-through-sap-btp-service-operator)
+   However, you can choose any other method of creating the instance and the secret, as long as the parameter for the OTLP ingestion is enabled in the instance. For details, see [Configuration Parameters](https://help.sap.com/docs/cloud-logging/cloud-logging/configuration-parameters).
+
 1. Wait for the instance to be created. You can check its status using the following command:
 
     ```
@@ -64,7 +65,7 @@ To create the SAP Cloud Logging service instance, follow these steps:
       secretName: sap-cloud-logging
       credentialsRotationPolicy:
         enabled: true
-        rotationFrequency: 168h
+        rotationFrequency: 1440h
 
     ```
     To apply the configuration, use the following command:


### PR DESCRIPTION
- Used SAP help documents whenever possible
- Use stable apiGroup for ServiceInstance in the example snippet
- Avoid the term "cls" in the file names as it is. no official abbrevation, better is to use cloud-logging
- Changed the name of the example ServiceInstance/Binding to be more user-friendly