### PR TITLE
Update CreateCAPProject notebook for CDS 9.x

### DIFF
--- a/documentation/notebooks/CreateCAPProject.capnb
+++ b/documentation/notebooks/CreateCAPProject.capnb
@@ -14,7 +14,7 @@
     {
         "kind": 2,
         "language": "shell",
-        "value": "rm -rf incident-management\ncds init incident-management\ncd incident-management",
+        "value": "rm -rf incident-management\ncds init incident-management --add nodejs\ncd incident-management\nnpm install",
         "outputs": []
     },
     {
@@ -74,7 +74,7 @@
     {
         "kind": 2,
         "language": "shell",
-        "value": "%%writefile \"db/data/sap.capire.incidents-conversation.csv\"\nID,up__ID,timestamp,author,message\n2b23bb4b-4ac7-4a24-ac02-aa10cabd842c,3b23bb4b-4ac7-4a24-ac02-aa10cabd842c,1995-12-17T03:24:00Z,Harry John,Can you please check if battery connections are fine?\n2b23bb4b-4ac7-4a24-ac02-aa10cabd843c,3a4ede72-244a-4f5f-8efa-b17e032d01ee,1995-12-18T04:24:00Z,Emily Elizabeth,Can you please check if there are any loose connections?\n9583f982-d7df-4aad-ab26-301d4a157cd7,3583f982-d7df-4aad-ab26-301d4a157cd7,2022-09-04T12:00:00Z,Sunny Sunshine,Please check why the solar panel is broken\n9583f982-d7df-4aad-ab26-301d4a158cd7,3ccf474c-3881-44b7-99fb-59a2a4668418,2022-09-04T13:00:00Z,Bradley Flowers,What exactly is wrong?",
+        "value": "%%writefile \"db/data/sap.capire.incidents-Incidents.conversation.csv\"\nID,up__ID,timestamp,author,message\n2b23bb4b-4ac7-4a24-ac02-aa10cabd842c,3b23bb4b-4ac7-4a24-ac02-aa10cabd842c,1995-12-17T03:24:00Z,Harry John,Can you please check if battery connections are fine?\n2b23bb4b-4ac7-4a24-ac02-aa10cabd843c,3a4ede72-244a-4f5f-8efa-b17e032d01ee,1995-12-18T04:24:00Z,Emily Elizabeth,Can you please check if there are any loose connections?\n9583f982-d7df-4aad-ab26-301d4a157cd7,3583f982-d7df-4aad-ab26-301d4a157cd7,2022-09-04T12:00:00Z,Sunny Sunshine,Please check why the solar panel is broken\n9583f982-d7df-4aad-ab26-301d4a158cd7,3ccf474c-3881-44b7-99fb-59a2a4668418,2022-09-04T13:00:00Z,Bradley Flowers,What exactly is wrong?",
         "outputs": []
     },
     {


### PR DESCRIPTION
## Summary
- Use `cds init --add nodejs` to generate a `package.json` with `@sap/cds` as a declared dependency (CDS 9 best practice)
- Add `npm install` after init so the project is self-contained
- Fix conversation CSV filename: `sap.capire.incidents-Incidents.conversation.csv` (CDS 9.x renames composition tables to include the parent entity name; old name `sap.capire.incidents-conversation.csv` would silently not load)

## Test plan
- [ ] Run all cells in the notebook — project initializes and installs cleanly
- [ ] `cds watch` starts without errors
- [ ] Conversation data loads correctly in the running service